### PR TITLE
WebAudio: Fix pitchbend bug in webaudio-wasm-wrapper.js

### DIFF
--- a/architecture/webaudio/webaudio-wasm-wrapper.js
+++ b/architecture/webaudio/webaudio-wasm-wrapper.js
@@ -3334,7 +3334,7 @@ var mydspPolyProcessorString = `
             {
                 for (var i = 0; i < this.fPitchwheelLabel.length; i++) {
                     var pw = this.fPitchwheelLabel[i];
-                    this.setParamValue(path, mydspPolyProcessor.remap(wheel, 0, 16383, pw.min, pw.max));
+                    this.setParamValue(pw.path, mydspPolyProcessor.remap(wheel, 0, 16383, pw.min, pw.max));
                     if (this.output_handler) {
                         this.output_handler(pw.path, this.getParamValue(pw.path));
                     }


### PR DESCRIPTION
This fixes an error while using pitchbend / pitchwheel in WASM MIDI polyvoice setup.

Previous pitchbend related changes in commit [4caac9a17681513e81b3691fac21c8dccf5e9e30](https://github.com/grame-cncm/faust/commit/4caac9a17681513e81b3691fac21c8dccf5e9e30). The previous commit changed `path` to `pw.path` in a few places but looks like one of the places wasn't updated, hence the bug.